### PR TITLE
Fix typo.

### DIFF
--- a/L15/1_lstm.ipynb
+++ b/L15/1_lstm.ipynb
@@ -479,7 +479,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- 25,002 not 25,000 because of the `<unk>` and `<pad>` tokens\n",
+    "- 20,002 not 20,000 because of the `<unk>` and `<pad>` tokens\n",
     "- PyTorch RNNs can deal with arbitrary lengths due to dynamic graphs, but padding is necessary for padding sequences to the same length in a given minibatch so we can store those in an array"
    ]
   },


### PR DESCRIPTION
Vocabulary size prints 20,002 but the note mentioned 25,002. This typo was fixed in this pull-request.